### PR TITLE
Fix docker #339

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM openanalytics/r-ver:4.0.5
 
-MAINTAINER Stijn Van Hoey stijn.vanhoey@inbo.be 
+MAINTAINER Stijn Van Hoey stijn.vanhoey@inbo.be
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gdal-bin \
     libproj15 \
     libgeos-3.8.0 libgeos-c1v5  \
-    curl \ 
+    curl \
     ca-certificates \
     pandoc \
     libudunits2-0 \
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Use the remotes package instead of devtools as it is mutch lighter
 RUN R -q -e "install.packages('remotes')"
 
-RUN R -q -e "remotes::install_cran(c('shiny', 'sp', 'plyr', 'reshape2', 'mgcv', 'rgdal', 'rgeos', 'raster', 'stringr', 'maptools', 'leaflet', 'mapview', 'flexdashboard', 'shinyjs'))"
+RUN R -q -e "remotes::install_cran(c('shiny', 'sp', 'dplyr', 'plyr', 'reshape2', 'mgcv', 'rgdal', 'rgeos', 'raster', 'stringr', 'maptools', 'leaflet', 'mapview', 'flexdashboard', 'shinyjs'))"
 RUN R -q -e "remotes::install_version('plotly', version = '4.9.2.1')"
 RUN R -q -e "remotes::install_version('DT', version = '0.12')"
 RUN R -q -e "remotes::install_github('inbo/INBOtheme')"
@@ -28,7 +28,8 @@ RUN R -q -e "remotes::install_github('daattali/shinycssloaders')"
 RUN R -q -e "webshot::install_phantomjs()"
 
 # Install the package without the source files ending up in the Docker image
-RUN --mount=target=/tmp/package,source=reporting-grofwild R -q -e "remotes::install_local('/tmp/package', dependencies=FALSE)"
+COPY reporting-grofwild /tmp/package
+RUN R -q -e "remotes::install_local('/tmp/package', dependencies=FALSE)"
 
 # set host
 COPY Rprofile.site /usr/local/lib/R/etc/


### PR DESCRIPTION
Fixes #340 
fixes #339 

Modified the Dockerfile to support older Docker engine versions.
I also had to add an additional package.

Currently when starting the container, I get the following error:

```
Warning in readChar(con, 5L, useBytes = TRUE) :
  cannot open compressed file '/usr/local/lib/R/site-library/reportingGrofwild/extdata/spatialData.RData', probable reason 'No such file or directory'
Error in readChar(con, 5L, useBytes = TRUE) : cannot open the connection
Calls: <Anonymous> ... eval -> eval -> ..stacktraceon.. -> load -> readChar
```

@SanderDevisscher do you know why this file is no longer part of the repo, or how this can be fixed? If not I will ask Machteld when she is back.
