### PR TITLE
551 herwerk tekst link naar hvv ipv limburgse jachtvereniging en fix typo

### DIFF
--- a/reporting-grofwild/R/app_frontPage.R
+++ b/reporting-grofwild/R/app_frontPage.R
@@ -21,7 +21,7 @@ frontUI <- function(speciesList){
       column(width = 6, offset = 3, align = "center",
         tags$span(
           style = "font-weight: bold;text-align: center;color: white;font-size: 2.1em;",
-          "Welkom op de faunabeheer-pagina van het",
+          "Welkom op de faunabeheerpagina van het",
           br(),
           "Instituut voor Natuur- en Bosonderzoek (INBO)"
         ),

--- a/reporting-grofwild/R/app_frontPage.R
+++ b/reporting-grofwild/R/app_frontPage.R
@@ -21,7 +21,7 @@ frontUI <- function(speciesList){
       column(width = 6, offset = 3, align = "center",
         tags$span(
           style = "font-weight: bold;text-align: center;color: white;font-size: 2.1em;",
-          "Welkom op de faunabeheerpagina van het",
+          "Welkom op de faunabeheer-pagina van het",
           br(),
           "Instituut voor Natuur- en Bosonderzoek (INBO)"
         ),

--- a/reporting-grofwild/inst/extdata/uiText.csv
+++ b/reporting-grofwild/inst/extdata/uiText.csv
@@ -44,7 +44,7 @@
     <b>Bronnen</b>
     <ul>
       <li>Onderstaande figuren en tabellen zijn gebaseerd op de beschikbare gegevens op datum van {{maxDate}}.</li>
-      <li>Deze gegevens komen uit het Meldpunt-schaderegistratie van het e-loket fauna en flora (<a href="https://www.natuurenbos.be/e-loket" target="_blank">Agentschap voor Natuur en Bos</a>), het project Dieren onder de wielen (Natuurpunt), Wilder (Limburgse Jagervereniging vzw) en meldingen van verkeersongevallen met wilde dieren uit andere bronnen.</li>
+      <li>Deze gegevens komen uit het Meldpunt-schaderegistratie van het e-loket fauna en flora (<a href="https://www.natuurenbos.be/e-loket" target="_blank">Agentschap voor Natuur en Bos</a>), het project Dieren onder de wielen (<a href="https://www.natuurpunt.be/projecten/dieren-onder-de-wielen" target="_blank">Natuurpunt</a>), Wilder (<a href="https://hvv.be/info/projecten-dossiers/wilder/" target="_blank">Hubertus Vereniging Vlaanderen</a>) en meldingen van verkeersongevallen met wilde dieren uit andere bronnen.</li>
       <li><u>Opgelet:</u> de data en figuren geven de meldingen weer zoals ze ingevoerd werden. Er gebeurt op dit moment geen systematische terreincontrole van deze meldingen. Ook eventuele dubbele meldingen van hetzelfde schadegeval worden niet gecontroleerd.</li>
       <li>De afbeeldingen zijn afkomstig van Vildaphoto. </li>
     </ul>


### PR DESCRIPTION
De juiste link werd toegevoegd, en faunabeheerpagina op de homepage werd veranderd naar faunabeheer-pagina