### PR TITLE
disable mapSchade tempfix

### DIFF
--- a/reporting-grofwild/inst/extdata/output-info-blacklist.csv
+++ b/reporting-grofwild/inst/extdata/output-info-blacklist.csv
@@ -10,19 +10,19 @@ Grauwe gans,exotenportaal
 Kievit,exotenportaal
 Houtduif,exotenportaal
 Vos,exotenportaal
-Wild zwijn,mapSchade
-Edelhert,mapSchade
-Damhert,mapSchade
-Ree,mapSchade
-Haas,mapSchade
-Konijn,mapSchade
-Patrijs,mapSchade
-Wilde Eend,mapSchade
-Smient,mapSchade
-Grauwe Gans,mapSchade
-Kievit,mapSchade
-Bever,mapSchade
-Wolf,mapSchade
-Houtduif,mapSchade
-Vos,mapSchade
-Verwilderde Kat,mapSchade
+Wild zwijn,mapSchadeUI
+Edelhert,mapSchadeUI
+Damhert,mapSchadeUI
+Ree,mapSchadeUI
+Haas,mapSchadeUI
+Konijn,mapSchadeUI
+Patrijs,mapSchadeUI
+Wilde Eend,mapSchadeUI
+Smient,mapSchadeUI
+Grauwe Gans,mapSchadeUI
+Kievit,mapSchadeUI
+Bever,mapSchadeUI
+Wolf,mapSchadeUI
+Houtduif,mapSchadeUI
+Vos,mapSchadeUI
+Verwilderde Kat,mapSchadeUI

--- a/reporting-grofwild/inst/extdata/output-info-blacklist.csv
+++ b/reporting-grofwild/inst/extdata/output-info-blacklist.csv
@@ -10,3 +10,19 @@ Grauwe gans,exotenportaal
 Kievit,exotenportaal
 Houtduif,exotenportaal
 Vos,exotenportaal
+Wild zwijn,mapSchade
+Edelhert,mapSchade
+Damhert,mapSchade
+Ree,mapSchade
+Haas,mapSchade
+Konijn,mapSchade
+Patrijs,mapSchade
+Wilde Eend,mapSchade
+Smient,mapSchade
+Grauwe Gans,mapSchade
+Kievit,mapSchade
+Bever,mapSchade
+Wolf,mapSchade
+Houtduif,mapSchade
+Vos,mapSchade
+Verwilderde Kat,mapSchade


### PR DESCRIPTION
Temporary blacklist mapSchade
#607

This pull request adds several new entries to the `output-info-blacklist.csv` file in the `reporting-grofwild` package. The main change is the inclusion of various animal species associated with the `mapSchade` source.

Blacklist expansion:

* Added multiple species (e.g., `Wild zwijn`, `Edelhert`, `Damhert`, `Ree`, `Haas`, `Konijn`, `Patrijs`, `Wilde Eend`, `Smient`, `Grauwe Gans`, `Kievit`, `Bever`, `Wolf`, `Houtduif`, `Vos`, `Verwilderde Kat`) to the blacklist, all linked to the `mapSchade` source.

