### PR TITLE
Update popup variables in certain wolf maps

### DIFF
--- a/reporting-grofwild/R/app_category_schade.R
+++ b/reporting-grofwild/R/app_category_schade.R
@@ -1,4 +1,3 @@
-
 #' Server function for an output (plot/table) of the 'schade' Category page
 #' @inheritParams reportingGrofwild-common-args
 #' @return reactive value with name of selected specie
@@ -465,9 +464,10 @@ schadeOutputServer <- function(id,
                   ),
                 plot4 = if ("mapAccidentsWolvesUI" %in% outputs)
                   mapLocationWolvesServer(
-                    id = "plot14",  
+                    id = "plot14",
                     variable = "Lot",
                     data = reactive(wolfOverzichtData),
+                    popup_variables = c("WolfID", "Status", "Leeftijdsklasse"),
                     preSelected = schadeSelection
                   ),
                 plot5 = if ("countSchadeWolvesUI-gemeldeSchade" %in% outputs)
@@ -546,6 +546,7 @@ schadeOutputServer <- function(id,
                   mapLocationWolvesServer(
                     id = "plot20",  
                     variable = "Lot",
+                    popup_variables = c("WolfID", "Status", "Leeftijdsklasse"),
                     data = reactive(wolfOverzichtData),
                     allSpatialData = spatialData,
                     preSelected = schadeSelection

--- a/reporting-grofwild/R/app_category_verspreiding.R
+++ b/reporting-grofwild/R/app_category_verspreiding.R
@@ -286,6 +286,7 @@ verspreidingOutputServer <- function(id,
                   mapDispersersWolvesServer(
                     id = "plot5",  
                     data = reactive(wolfOverzichtData),
+                    popup_variables = c("WolfID", "Herkomst"),
                     allSpatialData = spatialData,
                     preSelected = verspreidingSelection
                   )

--- a/reporting-grofwild/R/mapDispersersWolves.R
+++ b/reporting-grofwild/R/mapDispersersWolves.R
@@ -1,7 +1,7 @@
 #' Create map for disperser wolves
 #' @param data data.frame main data
 #' @param spatialData data.frame spatial data
-#' @inheritParams mapFlanders 
+#' @inheritParams mapFlanders
 #' @return leaflet map
 #' @author sjunius
 #' @importFrom leaflet leaflet addCircleMarkers addProviderTiles addPolygons setView addLegend
@@ -9,93 +9,110 @@
 #' @importFrom INBOtheme inbo_palette
 #' @export
 mapDispersersWolves <- function(
-  data, 
+  data,
+  popup_vars,
   spatialData,
   addGlobe = FALSE,
   showTerritoria = TRUE,
   legend = "topright"
 ) {
-  
   # Color palette for Years
   nColors <- length(unique(data$year))
   colors <- if (nColors < 10) {
-      inbo_palette(n = nColors) 
-    } else {
-      paletteNames <- c("Set3", "Paired", "Dark2", "Pastel2")
-      unlist(sapply(paletteNames, function(x)
-            suppressWarnings(brewer.pal(n = 12, name = x))))[1:nColors]
-    }
+    inbo_palette(n = nColors)
+  } else {
+    paletteNames <- c("Set3", "Paired", "Dark2", "Pastel2")
+    unlist(
+      sapply(
+        paletteNames,
+        function(x) {
+          suppressWarnings(brewer.pal(n = 12, name = x))
+        }
+      )
+    )[1:nColors]
+  }
   year_colors <- colorFactor(colors, sort(unique(data$year)))
-  
+
   # Color palette for territories
   territory_names <- sort(unique(spatialData$Territory))
-  territory_palette <- colorFactor(palette = brewer.pal(length(territory_names), "Set2"), domain = territory_names)
-  
-  
-  myMap <- leaflet(data,
-      options = leafletOptions(maxZoom = 12)) %>%
-    addMapPane("polylines", zIndex = 200) 
-  
-  if (showTerritoria)
-    myMap <- myMap %>%
-      addPolygons(data = spatialData,
-        fillColor = ~territory_palette(Territory),
-        color = "grey40", weight = 0.8,
+  territory_palette <- colorFactor(
+    palette = brewer.pal(length(territory_names), "Set2"),
+    domain = territory_names
+  )
+
+  myMap <- leaflet(
+    data,
+    options = leafletOptions(maxZoom = 12)
+  ) |>
+    addMapPane("polylines", zIndex = 200)
+
+  if (showTerritoria) {
+    myMap <- myMap |>
+      addPolygons(
+        data = spatialData,
+        fillColor = ~ territory_palette(Territory),
+        color = "grey40",
+        weight = 0.8,
         fillOpacity = 0.8,
         smoothFactor = 0.5,
         label = ~Territory,
         highlightOptions = highlightOptions(
-          weight = 1.5, 
-          color = "black"),
-        group = "Territoria") 
-  
-  
-  myMap <- myMap %>%
+          weight = 1.5,
+          color = "black"
+        ),
+        group = "Territoria"
+      )
+  }
+
+  myMap <- myMap |>
     addCircleMarkers(
       radius = 6,
-      fillColor = ~year_colors(year),
-      stroke = TRUE, color = "black", weight = 0.5, 
+      fillColor = ~ year_colors(year),
+      stroke = TRUE,
+      color = "black",
+      weight = 0.5,
       fillOpacity = 1,
-      popup = paste0("<li><strong> Jaar </strong>: ", data$year),
+      popup = construct_popup(data, popup_vars),
       group = "Zwervers"
-    ) %>%
+    ) |>
     setView(lng = 4, lat = 51, zoom = 8)
-  
+
   # Add world map
   if (addGlobe) {
-    
-    myMap <- myMap %>%
+    myMap <- myMap |>
       addProviderTiles("OpenStreetMap.HOT")
-    
   }
-  
+
   # Add legend
   if (legend != "none") {
-    myMap <- myMap %>% addLegend(legend,
+    myMap <- myMap |>
+      addLegend(
+        legend,
         pal = year_colors,
         values = ~year,
         title = "Zwervers",
         opacity = 1,
         labFormat = labelFormat(),
         group = "Zwervers",
-        layerId = "legend1") 
-      
-      if (showTerritoria)
-        myMap <- myMap %>%
-          addLegend(legend,
-            pal = territory_palette,
-            values = spatialData$Territory,
-            title = "Territoria",
-            opacity = 1,
-            labFormat = labelFormat(),
-            group = "Territoria",
-            layerId = "legend2")
+        layerId = "legend1"
+      )
+
+    if (showTerritoria) {
+      myMap <- myMap |>
+        addLegend(
+          legend,
+          pal = territory_palette,
+          values = spatialData$Territory,
+          title = "Territoria",
+          opacity = 1,
+          labFormat = labelFormat(),
+          group = "Territoria",
+          layerId = "legend2"
+        )
+    }
   }
-  
-  
+
   myMap
-  
-  
 }
 
 
@@ -112,7 +129,13 @@ mapDispersersWolves <- function(
 #' @importFrom leaflet renderLeaflet setView leafletProxy clearTiles leafletOutput
 #' @export
 mapDispersersWolvesServer <- function(
-  id, data, variable = "Lot", allSpatialData = NULL, preSelected = reactive(NULL)) {
+  id,
+  data,
+  variable = "Lot",
+  popup_variables = NULL,
+  allSpatialData = NULL,
+  preSelected = reactive(NULL)
+) {
   
   moduleServer(id,
     function(input, output, session) {
@@ -182,8 +205,12 @@ mapDispersersWolvesServer <- function(
       spacePlot <- reactive({
           req(subData())
           validate(need(nrow(subData()) > 0, "Er is geen data aanwezig voor de geselecteerde filters. Gelieve een andere selectie te maken."))
-          
-          myMap <- mapDispersersWolves(data = subData(), spatialData = spatialSpecificData(), addGlobe = TRUE,
+
+          if(is.null(popup_variables)){
+            popup_variables <- c(variable)
+          }
+
+          myMap <- mapDispersersWolves(data = subData(), popup_vars = popup_variables, spatialData = spatialSpecificData(), addGlobe = TRUE,
             legend = isolate(input$legend), showTerritoria = input$showTerritoria)
           
           if (!is.null(spatialData()))

--- a/reporting-grofwild/R/mapDispersersWolves.R
+++ b/reporting-grofwild/R/mapDispersersWolves.R
@@ -1,5 +1,6 @@
 #' Create map for disperser wolves
 #' @param data data.frame main data
+#' @param popup_vars variables to be shown in circle popup
 #' @param spatialData data.frame spatial data
 #' @inheritParams mapFlanders
 #' @return leaflet map

--- a/reporting-grofwild/R/mapLocationWolves.R
+++ b/reporting-grofwild/R/mapLocationWolves.R
@@ -1,13 +1,13 @@
 # Map(s) for location of wolves
-# 
+#
 # Author: sjunius
 ###############################################################################
 
 #' Create map for location wolves
-#' 
+#'
 #' @param data data.frame main data
 #' @param variable character with column name of interest
-#' @inheritParams mapFlanders 
+#' @inheritParams mapFlanders
 #' @return leaflet map
 #' @author sjunius
 #' @importFrom leaflet leaflet addCircleMarkers addProviderTiles fitBounds addLegend
@@ -15,69 +15,67 @@
 #' @importFrom INBOtheme inbo_palette
 #' @export
 mapLocationWolves <- function(
-        data, 
-        variable,
-        addGlobe = FALSE,
-        legend = "topright"
+  data,
+  variable,
+  popup_vars,
+  addGlobe = FALSE,
+  legend = "topright"
 ) {
-  
   # Color palette
   nColors <- length(levels(data$variable))
   colors <- if (nColors < 10) {
-      inbo_palette(n = nColors) 
-    } else {
-      paletteNames <- c("Set3", "Paired", "Dark2", "Pastel2")
-      unlist(sapply(paletteNames, function(x)
-            suppressWarnings(brewer.pal(n = 12, name = x))))[1:nColors]
-    }
-  
+    inbo_palette(n = nColors)
+  } else {
+    paletteNames <- c("Set3", "Paired", "Dark2", "Pastel2")
+    unlist(
+      sapply(
+        paletteNames,
+        function(x) {
+          suppressWarnings(brewer.pal(n = 12, name = x))
+        }
+      )
+    )[1:nColors]
+  }
+
   palette <- colorFactor(colors, levels(data$variable))
-  
-    myMap <- leaflet(data,
-        options = leafletOptions(maxZoom = 12)) %>%
-      addMapPane("polylines", zIndex = 200) %>%
-      addCircleMarkers(
-        radius = 6,
-        fillColor = ~palette(variable),
-        stroke = TRUE, color = "black", weight = 1, 
-        fillOpacity = 1,
-        popup = paste0("<h4>Info</h4>",  
-          "<ul>", 
-          "<li><strong> Jaar </strong>: ", data$year,
-          "<li><strong> ", variable, " </strong>: ", data$variable,
-          "</ul>"
-        )) %>%
-      setView(lng = 4, lat = 51, zoom = 8)
-    
-    # Add world map
-    if (addGlobe) {
-        
-        myMap <- myMap %>%
-                    addProviderTiles("OpenStreetMap.HOT")
-        
-    }
-    
-    # Add legend
-    if (legend != "none") {
-        
-        myMap <- addLegend(
-                map = myMap,
-                position = legend,
-                pal = palette, 
-                values = ~variable,
-                opacity = 1,
-                na.label = "onbekend",
-                title = ifelse(variable == "Lot", "Legende", "C1 en C2 waarnemingen"),
-                layerId = "legend"
-        )
-        
-        
-    }
-    
-    
-    myMap
-    
-    
+
+  myMap <- leaflet(
+    data,
+    options = leafletOptions(maxZoom = 12)
+  ) |>
+    addMapPane("polylines", zIndex = 200) |>
+    addCircleMarkers(
+      radius = 6,
+      fillColor = ~ palette(variable),
+      stroke = TRUE,
+      color = "black",
+      weight = 1,
+      fillOpacity = 1,
+      popup = construct_popup(data, popup_vars)
+    ) |>
+    setView(lng = 4, lat = 51, zoom = 8)
+
+  # Add world map
+  if (addGlobe) {
+    myMap <- myMap |>
+      addProviderTiles("OpenStreetMap.HOT")
+  }
+
+  # Add legend
+  if (legend != "none") {
+    myMap <- addLegend(
+      map = myMap,
+      position = legend,
+      pal = palette,
+      values = ~variable,
+      opacity = 1,
+      na.label = "onbekend",
+      title = ifelse(variable == "Lot", "Legende", "C1 en C2 waarnemingen"),
+      layerId = "legend"
+    )
+  }
+
+  myMap
 }
 
 
@@ -95,8 +93,14 @@ mapLocationWolves <- function(
 #' @importFrom leaflet renderLeaflet setView leafletProxy clearTiles leafletOutput
 #' @export
 mapLocationWolvesServer <- function(
-  id, data, variable = "Status", preSelected = reactive(NULL), allSpatialData = NULL,
-  definedYear = config::get("defaultYear", file = system.file("config.yml", package = "reportingGrofwild"))) {
+  id,
+  data,
+  variable = "Status",
+  popup_variables = NULL,
+  preSelected = reactive(NULL),
+  allSpatialData = NULL,
+  definedYear = config::get("defaultYear",file = system.file("config.yml", package = "reportingGrofwild"))
+) {
   
   moduleServer(id,
     function(input, output, session) {
@@ -176,7 +180,12 @@ mapLocationWolvesServer <- function(
           req(subData())
           validate(need(nrow(subData()) > 0, "Er is geen data aanwezig voor de geselecteerde filters. Gelieve een andere selectie te maken."))
           
-          myMap <- mapLocationWolves(data = subData(), variable = variable, addGlobe = TRUE) 
+          # If no popup variable is specified, revert to default variable
+          if(is.null(popup_variables)){
+            popup_variables <- c(variable)
+          }
+
+          myMap <- mapLocationWolves(data = subData(), variable = variable, popup_vars = popup_variables, addGlobe = TRUE) 
           
           if (!is.null(allSpatialData))
             myMap <- myMap %>%
@@ -299,7 +308,8 @@ mapLocationWolvesServer <- function(
       # Create final map (for download)
       finalMap <- reactive({
           
-          newMap <- mapLocationWolves(data = subData(), variable = variable, 
+          popup_info <- c("WolfID", "Status", "Leeftijdsklasse")
+          newMap <- mapLocationWolves(data = subData(), variable = variable, popup_vars = popup_info,
             addGlobe = input$globe %% 2 == 0, legend = input$legend)
           
           # save the zoom level and centering to the map object

--- a/reporting-grofwild/R/mapLocationWolves.R
+++ b/reporting-grofwild/R/mapLocationWolves.R
@@ -7,6 +7,7 @@
 #'
 #' @param data data.frame main data
 #' @param variable character with column name of interest
+#' @param popup_vars variables to be shown in circle popup
 #' @inheritParams mapFlanders
 #' @return leaflet map
 #' @author sjunius

--- a/reporting-grofwild/R/mapUtils.R
+++ b/reporting-grofwild/R/mapUtils.R
@@ -1,0 +1,24 @@
+#' Construct the right popup information to use with functions such as
+#' `addCircleMarkers` for leaflet maps.
+#' Will also display `year` as first item in the list.
+#'
+#' @param data The dataframe containing the information to be displayed
+#' @param popup_vars The columns of the dataframe that will be displayed
+construct_popup <- function(data, popup_vars) {
+  sapply(
+    rownames(data),
+    function(i) {
+      row <- data[i, ]
+      row_items <- paste(
+        sapply(popup_vars, function(var) {
+          glue::glue("<li><strong>{var}</strong>: {row[[var]]}</li>")
+        }),
+        collapse = ""
+      )
+      glue::glue(
+        "<h4>Info</h4><ul><li><strong>Jaar</strong>: {row$year}{row_items}</ul>"
+      )
+    },
+    USE.NAMES = FALSE
+  )
+}


### PR DESCRIPTION
Addresses #637:

**Kaart verkeersongevallen wolven**
- [x]  🟠👉 Past de popup aan zodat de WolfID, Status & Leeftijdsklasse weergegeven wordt.
- [x]  🟠👉 Verwijder “Lot” uit popup

**Kaart zwervers en territoria**
- [x] 🟠👉 geef ook WolfID & Herkomst weer in de popup

Does this by:
- Passing pop_up variables to `mapDispersersWolves` and `mapLocationWolves`
- Default pop_up variable remain set to the passed `variable`