### PR TITLE
Remove leaflet download icon from maps

### DIFF
--- a/reporting-grofwild/R/mapDispersersWolves.R
+++ b/reporting-grofwild/R/mapDispersersWolves.R
@@ -207,7 +207,6 @@ mapDispersersWolvesServer <- function(
               options = leaflet.extras2::easyprintOptions(
                 exportOnly = TRUE,
                 hideControlContainer = FALSE,  # Keep controls visible
-                hideClasses = c("leaflet-control-zoom", "leaflet-control-easyPrint")
               )
             )
           

--- a/reporting-grofwild/R/mapLocationWolves.R
+++ b/reporting-grofwild/R/mapLocationWolves.R
@@ -199,7 +199,6 @@ mapLocationWolvesServer <- function(
               options = leaflet.extras2::easyprintOptions(
                 exportOnly = TRUE,
                 hideControlContainer = FALSE,  # Keep controls visible
-                hideClasses = c("leaflet-control-zoom", "leaflet-control-easyPrint")
               )
             )
           

--- a/reporting-grofwild/R/mapSpread.R
+++ b/reporting-grofwild/R/mapSpread.R
@@ -365,7 +365,6 @@ mapSpreadServer <- function(id,
               options = leaflet.extras2::easyprintOptions(
                 exportOnly = TRUE,
                 hideControlContainer = FALSE,  # Keep controls visible
-                hideClasses = c("leaflet-control-zoom", "leaflet-control-easyPrint")
               )
             )
           
@@ -667,7 +666,6 @@ mapSpreadServer <- function(id,
                 options = leaflet.extras2::easyprintOptions(
                   exportOnly = TRUE,
                   hideControlContainer = FALSE,  # Keep controls visible
-                  hideClasses = c("leaflet-control-zoom", "leaflet-control-easyPrint")
                 )
               )
           })

--- a/reporting-grofwild/R/mapUTMWolves.R
+++ b/reporting-grofwild/R/mapUTMWolves.R
@@ -175,7 +175,6 @@ mapUTMWolvesServer <- function(
               options = leaflet.extras2::easyprintOptions(
                 exportOnly = TRUE,
                 hideControlContainer = FALSE,  # Keep controls visible
-                hideClasses = c("leaflet-control-zoom", "leaflet-control-easyPrint")
               )
             )
           

--- a/reporting-grofwild/inst/ui/www/style.css
+++ b/reporting-grofwild/inst/ui/www/style.css
@@ -538,3 +538,9 @@ body > .tabbable {
   font-size: 17px !important;
   line-height: 1.4;
 }
+
+.leaflet-control-easyPrint {
+  visibility: hidden;
+  width: 0px;
+  height: 0px;
+}


### PR DESCRIPTION
Addresses #637 

- [x]  🟠👉 Verwijder download icon op de leaflet (ook op andere wolven kaartjes)

Does this by:
- Change visibility and size of `easyPrint` controls in `style.css`
- Remove superfluous `hideClasses` settings (that were not working) in `leaflet.extras2::easyprintOptions`