### PR TITLE
Allow zooming on leaflet maps using controls by .25 interval

### DIFF
--- a/reporting-grofwild/R/mapDispersersWolves.R
+++ b/reporting-grofwild/R/mapDispersersWolves.R
@@ -43,7 +43,11 @@ mapDispersersWolves <- function(
 
   myMap <- leaflet(
     data,
-    options = leafletOptions(maxZoom = 12)
+    options = leafletOptions(
+      zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+      zoomDelta = 0.25,   # controls zoom increment
+      maxZoom = 12
+    )
   ) |>
     addMapPane("polylines", zIndex = 200)
 

--- a/reporting-grofwild/R/mapFlanders.R
+++ b/reporting-grofwild/R/mapFlanders.R
@@ -389,7 +389,13 @@ mapFlanders <- function(
     
   }
   
-  myMap <- leaflet(spatialData) %>%
+  myMap <- leaflet(
+      spatialData,
+      options = leafletOptions(
+        zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+        zoomDelta = 0.25   # controls zoom increment
+      )
+    ) %>%
     
     addPolygons(
       weight = 1, 

--- a/reporting-grofwild/R/mapLocationWolves.R
+++ b/reporting-grofwild/R/mapLocationWolves.R
@@ -42,7 +42,11 @@ mapLocationWolves <- function(
 
   myMap <- leaflet(
     data,
-    options = leafletOptions(maxZoom = 12)
+    options = leafletOptions(
+      zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+      zoomDelta = 0.25,   # controls zoom increment
+      maxZoom = 12
+    )
   ) |>
     addMapPane("polylines", zIndex = 200) |>
     addCircleMarkers(

--- a/reporting-grofwild/R/mapSchade.R
+++ b/reporting-grofwild/R/mapSchade.R
@@ -186,7 +186,12 @@ mapSchade <- function(
     }
     
     
-    myMap <- leaflet(schadeData) %>%
+    myMap <- leaflet(schadeData,
+        options = leafletOptions(
+          zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+          zoomDelta = 0.25   # controls zoom increment
+        )
+    ) %>%
             
             addCircleMarkers(
                     fillColor = ~palette(variable),

--- a/reporting-grofwild/R/mapSpread.R
+++ b/reporting-grofwild/R/mapSpread.R
@@ -55,7 +55,13 @@ mapSpread <- function(spreadShape, legend = "none", addGlobe = FALSE) {
   modelColors <- paletteMap(variable = unit, groupNames = levels(spreadShape$outcome))
   pal_model <- colorFactor(palette = modelColors$colors, levels = modelColors$levels, ordered = FALSE)
   
-  finalMap <- leaflet(spreadShape)
+  finalMap <- leaflet(
+    spreadShape,
+    options = leafletOptions(
+      zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+      zoomDelta = 0.25   # controls zoom increment
+    )
+  )
   
   finalMap <- finalMap %>%
     
@@ -143,7 +149,12 @@ mapSpread <- function(spreadShape, legend = "none", addGlobe = FALSE) {
 mapVerkeer <- function(trafficData, layers = c("oversteek", "ecorasters"), 
   addGlobe = FALSE) {
   
-  myMap <- leaflet() 
+  myMap <- leaflet(
+    options = leafletOptions(
+      zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+      zoomDelta = 0.25   # controls zoom increment
+    )
+  ) 
   
   if ("oversteek" %in% layers)
     myMap <- myMap %>%
@@ -186,7 +197,12 @@ mapVerkeer <- function(trafficData, layers = c("oversteek", "ecorasters"),
 mapBevers <- function(beverData, 
   addGlobe = FALSE, legend = "none") {
   
-  myMap <- leaflet() %>% 
+  myMap <- leaflet(
+      options = leafletOptions(
+      zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+      zoomDelta = 0.25   # controls zoom increment
+    )
+  ) %>% 
     addProviderTiles("OpenStreetMap.HOT") %>%
     setView(lng = 4, lat = 51, zoom = 8)
   

--- a/reporting-grofwild/R/mapUTMWolves.R
+++ b/reporting-grofwild/R/mapUTMWolves.R
@@ -31,7 +31,13 @@ mapUTMWolves <- function(
 #  
 #  palette <- colorFactor(colors, levels(data$variable))
   
-    myMap <- leaflet(data) %>%
+    myMap <- leaflet(
+      data,
+      options = leafletOptions(
+        zoomSnap = 0.25,   # allows zoom steps of 0.25 instead of 1
+        zoomDelta = 0.25   # controls zoom increment
+      )
+    ) %>%
       addMapPane("polylines", zIndex = 200) %>%
             
       addPolygons(fillColor = "#fee391",


### PR DESCRIPTION
Addresses issue in #637 

This allows zooming in using a .25 interval, instead of a 1 interval.
Also affects the initial zoom of maps --> it will snap to the nearest .25 interval

This does not affect zooming using the scrollwheel, I found no easy solution for that. (Tried setting the `this.scrollWheelZoom._delta = 0.25;` in an onRender function, but had no effect)