### PR TITLE
Install cmake and make in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM rocker/r-ver:4.3.2
 LABEL maintainer="Machteld Varewyck machteld.varewyck@openanalytics.eu"
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    cmake \
+    make \
+    g++ \
     libgdal-dev \
     libproj22 \
     libgeos3.10.2 libgeos-c1v5  \


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by adding essential build tools to the system dependencies. These additions help ensure that packages requiring compilation can be built successfully in the container.

* Added `cmake`, `make`, and `g++` to the list of installed packages in the `Dockerfile` to support building R packages from source.