### PR TITLE
Install 'fs' package in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM rocker/r-ver:4.3.2
 LABEL maintainer="Machteld Varewyck machteld.varewyck@openanalytics.eu"
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    libuv1 \
+    libuv1-dev \
     libgdal-dev \
     libproj22 \
     libgeos3.10.2 libgeos-c1v5  \
@@ -28,6 +30,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Use the remotes package instead of devtools as it is much lighter
 RUN R -q -e "install.packages('remotes')"
 
+RUN R -q -e "options(warn = 2); remotes::install_cran(c(fs'))"
 RUN R -q -e "options(warn = 2); remotes::install_version('shiny', version = '1.8.1.1', repos = 'https://cloud.r-project.org', upgrade = 'never')"
 RUN R -q -e "options(warn = 2); remotes::install_version('glue', version = '1.7.0', repos = 'https://cloud.r-project.org', upgrade = 'never')"
 RUN R -q -e "options(warn = 2); remotes::install_cran(c('sf', 'dplyr', 'plyr', 'reshape2', 'mgcv', 'stringr', 'leaflet', 'leaflet.extras', 'leaflet.extras2', 'flexdashboard', 'testthat', 'shinyjs', 'data.table', 'tinytex', 'tidyr', 'tidyselect', 'kableExtra', 'webshot2', 'slickR', 'ggplot2', 'ggforce', 'geojsonsf', 'reactable'))"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Use the remotes package instead of devtools as it is much lighter
 RUN R -q -e "install.packages('remotes')"
 
-RUN R -q -e "options(warn = 2); remotes::install_cran(c(fs'))"
+RUN R -q -e "options(warn = 2); remotes::install_cran('fs')"
 RUN R -q -e "options(warn = 2); remotes::install_version('shiny', version = '1.8.1.1', repos = 'https://cloud.r-project.org', upgrade = 'never')"
 RUN R -q -e "options(warn = 2); remotes::install_version('glue', version = '1.7.0', repos = 'https://cloud.r-project.org', upgrade = 'never')"
 RUN R -q -e "options(warn = 2); remotes::install_cran(c('sf', 'dplyr', 'plyr', 'reshape2', 'mgcv', 'stringr', 'leaflet', 'leaflet.extras', 'leaflet.extras2', 'flexdashboard', 'testthat', 'shinyjs', 'data.table', 'tinytex', 'tidyr', 'tidyselect', 'kableExtra', 'webshot2', 'slickR', 'ggplot2', 'ggforce', 'geojsonsf', 'reactable'))"


### PR DESCRIPTION
This pull request updates the `Dockerfile` to add missing system libraries required for R packages and ensures the `fs` package is installed explicitly. These changes improve compatibility and stability for R-based applications in the container.

Dependency updates and installation improvements:

* Added `libuv1` and `libuv1-dev` to the list of system packages installed, which are required for certain R packages that depend on the `libuv` library.
* Explicitly installs the `fs` R package using `remotes::install_cran`, ensuring it is available for other packages that may depend on it.

Alternative to #657 the time to beat [1h 28m 19s](https://github.com/inbo/reporting-rshiny-grofwildjacht/actions/runs/23600515922/usage) see https://github.com/inbo/reporting-rshiny-grofwildjacht/actions/runs/23636223778 