### PR TITLE
Add libuv1-dev to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     make \
     g++ \
     libgdal-dev \
+    libuv1-dev \
     libproj22 \
     libgeos3.10.2 libgeos-c1v5  \
     libcurl4-openssl-dev \


### PR DESCRIPTION
This pull request makes a small update to the Docker build configuration by adding a new library dependency.

- Added the `libuv1-dev` package to the list of dependencies installed in the `Dockerfile` to support building or running components that require libuv.