### PR TITLE
fix #670

### DIFF
--- a/reporting-grofwild/R/mapSpread.R
+++ b/reporting-grofwild/R/mapSpread.R
@@ -605,7 +605,7 @@ mapSpreadServer <- function(id,
               column(4, selectizeInput(inputId = ns("versprYear"), label = "Jaar van verspreiding:",
                   choices = c("Geen", availableYears$verspreiding), selected = "Geen")),
               column(4, selectizeInput(inputId = ns("predYear"), label = "Jaar van predictie:",
-                  choices = availableYears$prediction, selected = min(availableYears$prediction))),
+                  choices = availableYears$prediction, selected = max(availableYears$prediction))),
               column(4, checkboxGroupInput(inputId = ns("rb"), label = "Kans op vestiging in jaar van predictie:",
                   choices = choices, selected = choices))
             )


### PR DESCRIPTION
This pull request makes a small change to the default selection behavior for the prediction year in the `mapSpreadServer` function. Now, the latest available prediction year will be selected by default instead of the earliest.

- In `mapSpreadServer` within `reporting-grofwild/R/mapSpread.R`, changed the default for the `predYear` select input to use the maximum (latest) available prediction year instead of the minimum (earliest).

te testen op faunabeheer-uat.inbo.be 😉 